### PR TITLE
Allow multipart uploads for account signup submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update `processApplication` mutation to use `Upload` variables, allowing files to be sent as multipart form data.
+
 ## [0.0.12] - 2020-06-18
 
 ### Changed

--- a/react/components/AccountCreateContext.tsx
+++ b/react/components/AccountCreateContext.tsx
@@ -23,11 +23,14 @@ interface AccountCreateContextProps {
 }
 
 type ReducerActions =
-  | { type: 'SET_BUSINESS_FIELD'; args: { field: string; value: string } }
+  | {
+      type: 'SET_BUSINESS_FIELD'
+      args: { field: string; value: string | File }
+    }
   | { type: 'SET_BUSINESS_ADDRESS'; args: { address: Address } }
   | {
       type: 'SET_PERSONAL_FIELD'
-      args: { field: string; value: string | boolean }
+      args: { field: string; value: string | boolean | File }
     }
   | { type: 'SET_PERSONAL_ADDRESS'; args: { address: Address } }
   | { type: 'SET_TOS_FIELD'; args: { field: string; value: string } }
@@ -49,7 +52,6 @@ const initialAccountCreateState = {
     email: '',
     phoneNumber: '',
     docType: 'CONTRATO-SOCIAL',
-    physicalDocValue: '',
     physicalDocFileName: '',
   },
   businessAddress: {
@@ -74,7 +76,6 @@ const initialAccountCreateState = {
     lastName: '',
     firstName: '',
     docType: 'CNH',
-    physicalDocValue: '',
     physicalDocFileName: '',
     virtualDocValue: '',
     virtualDocExp: '',

--- a/react/components/AccountCreatePages/DocumentDropzone.tsx
+++ b/react/components/AccountCreatePages/DocumentDropzone.tsx
@@ -68,16 +68,16 @@ const DocumentDropzone: StorefrontFunctionComponent<DropProps> = ({
   const dispatch = useAccountCreateDispatch()
   const handles = useCssHandles(CSS_HANDLES)
 
-  function getBase64(file: File) {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => {
-        resolve(reader.result)
-      }
-      reader.onerror = reject
-      reader.readAsDataURL(file)
-    })
-  }
+  // function getBase64(file: File) {
+  //   return new Promise((resolve, reject) => {
+  //     const reader = new FileReader()
+  //     reader.onload = () => {
+  //       resolve(reader.result)
+  //     }
+  //     reader.onerror = reject
+  //     reader.readAsDataURL(file)
+  //   })
+  // }
 
   const onDropImage = async (files: File[]) => {
     setError(null)
@@ -85,7 +85,7 @@ const DocumentDropzone: StorefrontFunctionComponent<DropProps> = ({
       if (files?.[0]) {
         setIsLoading(true)
 
-        const base64EncodedFile = (await getBase64(files[0])) as string
+        // const base64EncodedFile = (await getBase64(files[0])) as string
 
         dispatch({
           type:
@@ -93,8 +93,9 @@ const DocumentDropzone: StorefrontFunctionComponent<DropProps> = ({
               ? 'SET_BUSINESS_FIELD'
               : 'SET_PERSONAL_FIELD',
           args: {
-            field: 'physicalDocValue',
-            value: base64EncodedFile.split(',')[1],
+            field: 'physicalDocFile',
+            value: files[0],
+            // value: base64EncodedFile.split(',')[1],
           },
         })
         dispatch({

--- a/react/components/AccountCreatePages/DocumentsPage.tsx
+++ b/react/components/AccountCreatePages/DocumentsPage.tsx
@@ -85,8 +85,8 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
 
   useEffect(() => {
     if (
-      businessInformation.physicalDocValue !== '' &&
-      personalInformation.physicalDocValue !== ''
+      businessInformation.physicalDocFile &&
+      personalInformation.physicalDocFile
     ) {
       dispatch({
         type: 'SET_DOCUMENTS_VALID',
@@ -103,10 +103,10 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
       })
     }
   }, [
-    businessInformation.physicalDocValue,
+    businessInformation.physicalDocFile,
     dispatch,
     documentsValid,
-    personalInformation.physicalDocValue,
+    personalInformation.physicalDocFile,
   ])
 
   async function handlePageModeChange(newPageMode: string) {
@@ -164,7 +164,6 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
               physicalDocument: [
                 {
                   type: businessInformation.docType,
-                  value: businessInformation.physicalDocValue,
                 },
               ],
             },
@@ -189,7 +188,6 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
               physicalDocument: [
                 {
                   type: personalInformation.docType,
-                  value: personalInformation.physicalDocValue,
                 },
               ],
             },
@@ -203,6 +201,8 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
             userAgent: navigator.userAgent,
           },
         },
+        businessInfoFile: businessInformation.physicalDocFile,
+        personalInfoFile: personalInformation.physicalDocFile,
       },
     }).then(
       response => {
@@ -257,7 +257,7 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
             <Button
               variation="primary"
               onClick={() => handlePageModeChange('select')}
-              disabled={personalInformation.physicalDocValue === ''}
+              disabled={!personalInformation.physicalDocFile}
             >
               <FormattedMessage id="store/flowFinance.accountCreate.documents.continueLabel" />
             </Button>
@@ -277,7 +277,7 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
             <Button
               variation="primary"
               onClick={() => handlePageModeChange('select')}
-              disabled={businessInformation.physicalDocValue === ''}
+              disabled={!businessInformation.physicalDocFile}
             >
               <FormattedMessage id="store/flowFinance.accountCreate.documents.continueLabel" />
             </Button>
@@ -296,17 +296,13 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
           >
             <div className={`${handles.documentTypeContainer} w-50 pa2 tc`}>
               <img
-                src={
-                  personalInformation.physicalDocValue === ''
-                    ? IconIdGray
-                    : IconId
-                }
+                src={!personalInformation.physicalDocFile ? IconIdGray : IconId}
                 alt="ID Icon"
                 className={`${handles.documentTypeIcon}`}
               />
               <div
                 className={`${handles.documentTypeLabel} ma3 ${
-                  personalInformation.physicalDocValue === '' ? 'c-muted-4' : ''
+                  !personalInformation.physicalDocFile ? 'c-muted-4' : ''
                 }`}
               >
                 <FormattedMessage id="store/flowFinance.accountCreate.documents.personalIdLabel" />
@@ -343,7 +339,7 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
             <div className={`${handles.documentTypeContainer} w-50 pa2 tc`}>
               <img
                 src={
-                  businessInformation.physicalDocValue === ''
+                  !businessInformation.physicalDocFile
                     ? IconContratoGray
                     : IconContrato
                 }
@@ -352,7 +348,7 @@ const DocumentsPage: StorefrontFunctionComponent<DocumentsPageProps &
               />
               <div
                 className={`${handles.documentTypeLabel} ma3 ${
-                  businessInformation.physicalDocValue === '' ? 'c-muted-4' : ''
+                  !businessInformation.physicalDocFile ? 'c-muted-4' : ''
                 }`}
               >
                 <FormattedMessage id="store/flowFinance.accountCreate.documents.businessIdLabel" />

--- a/react/graphql/ProcessApplication.graphql
+++ b/react/graphql/ProcessApplication.graphql
@@ -1,6 +1,13 @@
-mutation ProcessApplication($application: ApplicationInput!) {
-  processApplication(application: $application)
-    @context(provider: "vtex.flow-finance-api") {
+mutation ProcessApplication(
+  $application: ApplicationInput!
+  $businessInfoFile: Upload!
+  $personalInfoFile: Upload!
+) {
+  processApplication(
+    application: $application
+    businessInfoFile: $businessInfoFile
+    personalInfoFile: $personalInfoFile
+  ) @context(provider: "vtex.flow-finance-api") {
     success
     error
   }

--- a/react/typings/flow-finance.d.ts
+++ b/react/typings/flow-finance.d.ts
@@ -5,7 +5,7 @@ export interface BusinessInformation {
   email: string
   phoneNumber: string
   docType: string
-  physicalDocValue: string
+  physicalDocFile?: File
   physicalDocFileName: string
 }
 
@@ -32,7 +32,7 @@ export interface PersonalInformation {
   lastName: string
   firstName: string
   docType: string
-  physicalDocValue: string
+  physicalDocFile?: File
   physicalDocFileName: string
   virtualDocValue: string
   virtualDocExp?: string


### PR DESCRIPTION
By default, VTEX GraphQL requests are limited to 1MB of data. To get around this limitation, this PR implements the GraphQL `Upload` variable type which sends the file as a multipart form data stream. `vtex.flow-finance-api` is also being updated to match.

New version linked here: https://flowfinance--sandboxusdev.myvtex.com/flow-finance and has been successfully tested with files larger than 1MB.